### PR TITLE
Display the next meetup event

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require rails_helper

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "sass-rails", "~> 5.0"
 gem "sprockets", "~> 3.7.2"
 gem "title"
 gem "uglifier"
+gem "httparty"
 
 group :development do
   gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     jquery-rails (4.3.1)
@@ -114,6 +116,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.1)
+    multi_xml (0.6.0)
     nio4r (2.2.0)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
@@ -236,6 +239,7 @@ DEPENDENCIES
   factory_bot_rails
   flutie
   formulaic
+  httparty
   jquery-rails
   launchy
   listen

--- a/app/assets/stylesheets/components/_events.scss
+++ b/app/assets/stylesheets/components/_events.scss
@@ -34,12 +34,16 @@
   min-width: 50%;
 }
 
-.upcoming-event-title {
+.upcoming-event-header {
   color: $red;
   font-family: $heading-font-family;
   font-weight: 500;
   font-size: 24px;
   margin-top: 1.5rem;
+}
+
+.upcoming-event-title {
+  font-weight: bold;
 }
 
 .upcoming-event-date {

--- a/app/clients/http_client.rb
+++ b/app/clients/http_client.rb
@@ -1,0 +1,16 @@
+class HttpClient
+  def self.get(uri, options = {})
+    new.get(uri, options)
+  end
+
+  def get(uri, options)
+    response = HTTParty.get(uri, options)
+    build_response(response)
+  end
+
+  private
+
+  def build_response(response)
+    HttpResponse.new(success: response.success?, body: response.body)
+  end
+end

--- a/app/clients/meetup_api.rb
+++ b/app/clients/meetup_api.rb
@@ -1,0 +1,17 @@
+class MeetupApi
+  BASE_URL = "https://api.meetup.com/".freeze
+
+  def upcoming_events(group_name)
+    HttpClient.get(events_path(group_name))
+  end
+
+  private
+
+  def events_path(group_name)
+    build_url("#{group_name}/events")
+  end
+
+  def build_url(path)
+    URI.join(BASE_URL, path).to_s
+  end
+end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,4 +1,5 @@
 class HomesController < ApplicationController
   def show
+    @upcoming_event = EventService.next_event(group_name: "bostonrb")
   end
 end

--- a/app/models/http_response.rb
+++ b/app/models/http_response.rb
@@ -1,0 +1,17 @@
+class HttpResponse
+  def initialize(body:, success:)
+    @body = body
+    @success = success
+  end
+
+  def parsed_body
+    JSON.parse(body)
+  end
+
+  def success?
+    success
+  end
+
+  private
+  attr_reader :body, :success
+end

--- a/app/models/unknown_meetup_event.rb
+++ b/app/models/unknown_meetup_event.rb
@@ -1,0 +1,5 @@
+class UnknownMeetupEvent
+  def found?
+    false
+  end
+end

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -1,0 +1,27 @@
+class EventService
+  def self.next_event(group_name:, data_source: MeetupApi.new)
+    new(group_name, data_source).next_event
+  end
+
+  def initialize(group_name, data_source)
+    @group_name = group_name
+    @data_source = data_source
+  end
+
+  def next_event
+    response = data_source.upcoming_events(group_name)
+
+    if upcoming_events_found?(response)
+      MeetupEvent.new(response.parsed_body.first)
+    else
+      UnknownMeetupEvent.new
+    end
+  end
+
+  private
+  attr_reader :group_name, :data_source
+
+  def upcoming_events_found?(response)
+    response.success? && response.parsed_body.present?
+  end
+end

--- a/app/view_models/meetup_event.rb
+++ b/app/view_models/meetup_event.rb
@@ -1,0 +1,83 @@
+class MeetupEvent
+  def initialize(data)
+    @data = ActiveSupport::HashWithIndifferentAccess.new(data)
+  end
+
+  def found?
+    true
+  end
+
+  def name
+    data[:name]
+  end
+
+  def date
+    date = data[:local_date]
+
+    if date.present?
+      date.to_date.to_s(:long)
+    end
+  end
+
+  def formatted_start_time
+    if start_time.present?
+      start_time.to_s(:time_with_am_pm)
+    else
+      "Start Time is TBD"
+    end
+  end
+
+  def formatted_end_time
+    if end_time.present?
+      end_time.to_s(:time_with_am_pm)
+    else
+      "End Time is TBD"
+    end
+  end
+
+  def venue_name
+    venue[:name]
+  end
+
+  def address
+    venue[:address_1]
+  end
+
+  def city
+    venue[:city]
+  end
+
+  def state
+    venue[:state]
+  end
+
+  private
+  attr_reader :data
+
+  def start_time
+    local_start_time = data[:local_time]
+
+    if local_start_time
+      Time.parse(local_start_time)
+    end
+  end
+
+  def end_time
+    if start_time.present? && duration.present?
+      num_of_hours = duration_in_hours(duration)
+      start_time + num_of_hours.hours
+    end
+  end
+
+  def duration
+    data[:duration]
+  end
+
+  def duration_in_hours(duration)
+    duration/1000/60/60
+  end
+
+  def venue
+    data.fetch(:venue)
+  end
+end

--- a/app/views/homes/_event_details.html.erb
+++ b/app/views/homes/_event_details.html.erb
@@ -1,0 +1,28 @@
+<p class="upcoming-event-title">
+  <%= event.name %>
+</p>
+
+<div class="upcoming-event-date">
+  <span>
+    <%= event.date %></br>
+    <%= "#{event.formatted_start_time} to #{event.formatted_end_time}" %>
+  </span>
+</div>
+
+<div class="upcoming-event-location">
+  <span>
+    <%= event.venue_name %></br>
+    <%= event.address %></br>
+    <%= "#{event.city}, #{event.state}" %>
+  </span>
+</div>
+
+<div class="upcoming-event__buttons">
+  <%= link_to("RSVP", "#", class: "upcoming-event__button") %>
+  <%= link_to(
+    "See all events",
+    "https://www.meetup.com/bostonrb/events/",
+    class: "upcoming-event__button",
+    target: "_blank"
+  ) %>
+</div>

--- a/app/views/homes/_events.html.erb
+++ b/app/views/homes/_events.html.erb
@@ -1,56 +1,26 @@
 <section>
   <div class="events-container">
+    <div class="events-container__item" data-role="upcoming-event-details">
+      <p class="upcoming-event-header">Our next event</p>
 
-      <div class="events-container__item">
-        <p class="upcoming-event-title">
-          Our next event
-        </p>
-        <p class="upcoming-event-header">
-          <strong>Meeting</strong> (second Tuesday of every month)
-        </p>
-        <div class="upcoming-event-date">
-          <span>
-            February 3, 2018</br>
-            6:45PM to 10:00PM
-          </span>
-        </div>
-        <div class="upcoming-event-location">
-          <span>
-            ezCater</br>
-            101 Arch St, 15th Floor</br>
-            Boston, MA
-          </span>
-        </div>
-        <div class="upcoming-event__buttons">
-          <%= link_to("RSVP", "#", class: "upcoming-event__button") %>
-          <%= link_to(
-            "See all events",
-            "https://www.meetup.com/bostonrb/events/",
-            class: "upcoming-event__button",
-            target: "_blank"
-          ) %>
-        </div>
-      </div>
+      <%= render "upcoming_event", event: @upcoming_event %>
+    </div>
 
     <div class="events-container__item">
       <div class="card">
-        <p class="card__title">
-          Project nights
-        </p>
-        <p class="card__header">
-          First Tuesday of the month
-        </p>
+        <p class="card__title">Project nights</p>
+        <p class="card__header">First Tuesday of the month</p>
+
         <span>
-          Get help with rails, hack on some open source, meet other Ruby enthusiasts.
+          Get help with Rails, hack on some open source, meet other Ruby
+          enthusiasts.
         </span>
       </div>
+
       <div class="card">
-        <p class="card__title">
-          Meetings
-        </p>
-        <p class="card__header">
-          Second Tuesday of the month
-        </p>
+        <p class="card__title">Meetings</p>
+        <p class="card__header">Second Tuesday of the month</p>
+
         <span>
           Two long-form talks about something cool created with Ruby.
         </span>

--- a/app/views/homes/_no_upcoming_event.html.erb
+++ b/app/views/homes/_no_upcoming_event.html.erb
@@ -1,0 +1,12 @@
+<p class="upcoming-event-title">There are no upcoming events.</p>
+
+<p>Please check back at a later time.</p>
+
+<div class="upcoming-event__buttons">
+  <%= link_to(
+    "See all events",
+    "https://www.meetup.com/bostonrb/events/",
+    class: "upcoming-event__button",
+    target: "_blank"
+  ) %>
+</div>

--- a/app/views/homes/_upcoming_event.html.erb
+++ b/app/views/homes/_upcoming_event.html.erb
@@ -1,0 +1,5 @@
+<% if @upcoming_event.found? %>
+  <%= render "event_details", event: @upcoming_event %>
+<% else %>
+  <%= render "no_upcoming_event", event: @upcoming_event %>
+<% end %>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:time_with_am_pm] = "%-l:%M%p"

--- a/spec/clients/meetup_api_spec.rb
+++ b/spec/clients/meetup_api_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe MeetupApi do
+  describe ".upcoming_events" do
+    it "requests a group's future events from the Meetup API" do
+      meetup_group = "ruby-friends"
+      http_response = HttpResponse.new(success: true, body: "")
+
+      allow(HttpClient).to receive(:get).and_return(http_response)
+
+      MeetupApi.new.upcoming_events(meetup_group)
+
+      expect(HttpClient)
+        .to have_received(:get)
+        .with("https://api.meetup.com/#{meetup_group}/events")
+    end
+  end
+end

--- a/spec/features/user_views_upcoming_events_spec.rb
+++ b/spec/features/user_views_upcoming_events_spec.rb
@@ -1,0 +1,24 @@
+RSpec.feature "user views details for the next event" do
+  scenario "successfully" do
+    stub_request_to_meetup_api
+
+    visit root_path
+
+    within("[data-role='upcoming-event-details']") do
+      expect(page).to have_content("Fake Project Night")
+      expect(page).to have_content("thoughtbot")
+      expect(page).to have_content("41 Winter Street, 6th Floor")
+      expect(page).to have_content("Boston, MA")
+      expect(page).to have_content("6:00PM to 8:00PM")
+    end
+  end
+
+  def stub_request_to_meetup_api
+    stub_request(:get, /api.meetup.com/).
+      to_return(status: 200, body: events_json)
+  end
+
+  def events_json
+    File.read(Rails.root.join("spec/fixtures/meetup_events.json"))
+  end
+end

--- a/spec/fixtures/meetup_events.json
+++ b/spec/fixtures/meetup_events.json
@@ -1,0 +1,45 @@
+[
+  {
+    "created": 1525221805000,
+    "duration": 7200000,
+    "id": "250356742",
+    "name": "Fake Project Night",
+    "rsvp_limit": 75,
+    "status": "upcoming",
+    "time": 1525816800000,
+    "local_date": "2018-05-08",
+    "local_time": "18:00",
+    "rsvp_close_offset": "PT25H",
+    "updated": 1525273120000,
+    "utc_offset": -14400000,
+    "waitlist_count": 0,
+    "yes_rsvp_count": 23,
+    "venue": {
+      "id": 24798784,
+      "name": "thoughtbot",
+      "lat": 42.35497283935547,
+      "lon": -71.05880737304688,
+      "repinned": false,
+      "address_1": "41 Winter Street, 6th Floor",
+      "city": "Boston",
+      "state": "MA",
+      "country": "US",
+      "localized_country_name": "USA"
+    },
+    "group": {
+      "created": 1469574115000,
+      "name": "Boston Ruby Group",
+      "id": 20228196,
+      "join_mode": "approval",
+      "lat": 42.349998474121094,
+      "lon": -71.04000091552734,
+      "urlname": "bostonrb",
+      "who": "Rubyists",
+      "localized_location": "Boston, MA",
+      "region": "en_US"
+    },
+    "link": "https://www.meetup.com/bostonrb/events/250356742/",
+    "description": "<p>For the month of May, we'll be doing a 2-parter!</p> <p>Depending on submissions, we'll be doing lightning talks for the first 30-45 minutes. To submit a talk, go to <a href=\"https://www.papercall.io/bostonrb\" class=\"linkified\">https://www.papercall.io/bostonrb</a>, tell us about your talk (anything Ruby- or tech-related!), and remember to select the \"Lightning Talk\" format before you hit submit!</p> <p>After the talks, we'd like to hold a \"Town Hall Meeting\" to discuss any ideas you might have for future BostonRB events.</p> <p>The Town Hall Meeting will be an open forum for you to tell us where we're doing well and where we can improve. We're also looking for more people to be involved in organizing events for the Boston Ruby community, so please drop by and talk to us!</p> <p>Rough schedule:</p> <p>* 6:00pm - Eat, mingle.<br/>* 6:20pm - Lightning talks begin.<br/>* 7:00/7:15pm - Town Hall Meeting begins.</p> <p>Thanks to ezCater (<a href=\"https://www.ezcater.com/\" class=\"linkified\">https://www.ezcater.com/</a>) for sponsoring food and space for this Meetup!</p> ",
+    "visibility": "public"
+  }
+]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RACK_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
+require "spec_helper"
 require "rspec/rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }

--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe EventService do
+  describe "#next_event" do
+    it "returns the next event for the given meetup group" do
+      group_name = "my-awesome-group"
+      meetup_events = build_events_for(group_name)
+      fake_meetup_api = FakeMeetupApi.new(events: meetup_events)
+
+      event = EventService.next_event(
+        group_name: "my-awesome-group",
+        data_source: fake_meetup_api
+      )
+
+      expect(event).to be_found
+
+      event_name = JSON.parse(meetup_events_json).first["name"]
+      expect(event.name).to eq(event_name)
+    end
+
+    context "when a future event is not found" do
+      it "returns an unknown event" do
+        fake_meetup_api = FakeMeetupApi.new(events: [])
+
+        event = EventService.next_event(
+          group_name: "group-with-zero-upcoming-events",
+          data_source: fake_meetup_api
+        )
+
+        expect(event).not_to be_found
+        expect(event).to be_an_instance_of(UnknownMeetupEvent)
+      end
+    end
+
+    context "when the response fails" do
+      it "returns an unknown event" do
+        meetup_group_name = "invalid-meetup-group"
+        fake_meetup_api = FakeMeetupApi.new(events: [], success: false)
+
+        event = EventService.next_event(
+          group_name: meetup_group_name,
+          data_source: fake_meetup_api
+        )
+
+        expect(event).not_to be_found
+        expect(event).to be_an_instance_of(UnknownMeetupEvent)
+      end
+    end
+  end
+
+  def build_events_for(group_name)
+    JSON.parse(meetup_events_json).map do |event|
+      event.deep_merge("group" => { "urlname" => group_name })
+    end
+  end
+
+  def meetup_events_json
+    File.read(Rails.root.join("spec/fixtures/meetup_events.json"))
+  end
+end

--- a/spec/support/clients/fake_meetup_api.rb
+++ b/spec/support/clients/fake_meetup_api.rb
@@ -1,0 +1,23 @@
+class FakeMeetupApi
+  def initialize(events:, success: true)
+    @events = events
+    @success = success
+  end
+
+  def upcoming_events(meetup_group_name)
+    HttpResponse.new(
+      body: filter_events(meetup_group_name).to_json,
+      success: success
+    )
+  end
+
+  private
+
+  attr_reader :events, :success
+
+  def filter_events(meetup_group_name)
+    events.select do |event|
+      event.dig("group", "urlname") == meetup_group_name
+    end
+  end
+end

--- a/spec/view_models/meetup_event_spec.rb
+++ b/spec/view_models/meetup_event_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe MeetupEvent do
+  describe "#name" do
+    it "returns the name of the event" do
+      meetup_event_data = {"name" => "Awesome Event"}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.name).to eq("Awesome Event")
+    end
+  end
+
+  describe "#date" do
+    it "returns the date formatted as month day, year" do
+      meetup_event_data = {"local_date" => "2018-05-08"}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.date).to eq("May 08, 2018")
+    end
+  end
+
+  describe "#formatted_start_time" do
+    it "returns the start time formatted with AM/PM" do
+      meetup_event_data = {"local_time" => "18:00"}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.formatted_start_time).to eq("6:00PM")
+    end
+
+    it "returns a message when the start time is unknown" do
+      meetup_event_data = {"local_time" => nil}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.formatted_start_time).to eq("Start Time is TBD")
+    end
+  end
+
+  describe "#formatted_end_time" do
+    it "returns the end time formatted with AM/PM" do
+      meetup_event_data = {
+        "local_time" => "18:00",
+        "duration" => 7200000
+      }
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.formatted_end_time).to eq("8:00PM")
+    end
+
+    it "returns a message when the end time is unknown" do
+      meetup_event_data = {"duration" => nil}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.formatted_end_time).to eq("End Time is TBD")
+    end
+  end
+
+  describe "#venue_name" do
+    it "returns the name of the venue" do
+      meetup_event_data = {"venue" => {"name" => "thoughtbot"}}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.venue_name).to eq("thoughtbot")
+    end
+  end
+
+  describe "#address" do
+    it "returns the venue address" do
+      meetup_event_data = {"venue" => {"address_1" => "41 Winter Street"}}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.address).to eq("41 Winter Street")
+    end
+  end
+
+  describe "#city" do
+    it "returns the venue city" do
+      meetup_event_data = {"venue" => {"city" => "Boston"}}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.city).to eq("Boston")
+    end
+  end
+
+  describe "#state" do
+    it "returns the venue state" do
+      meetup_event_data = {"venue" => {"state" => "Massachusetts"}}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.state).to eq("Massachusetts")
+    end
+  end
+end

--- a/spec/views/events_view_spec.rb
+++ b/spec/views/events_view_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe "homes/_events.html.erb" do
+  context "when the next event is unknown" do
+    it "display that the upcoming event is unknown" do
+      assign(:upcoming_event, UnknownMeetupEvent.new)
+
+      render
+
+      expect(rendered).to match("There are no upcoming events.")
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [I want to know what event is coming up next](https://trello.com/c/PmNxY8KH)

Summary:
Displays the next Boston Ruby Group meetup event by pulling the next
event from the Meetup API.

In the event that there are no upcoming events, or the request to the Meetup API fails, the page displays the message that there are no upcoming events. I didn't spend much time on the design of the "no upcoming events" state as we are in the process of updating the existing design.

Screenshot of upcoming event:
![screen shot 2018-06-22 at 6 33 23 pm](https://user-images.githubusercontent.com/4016985/41802554-8fb29c76-764f-11e8-896e-67be077d8876.png)



Screenshot when upcoming event is TBD:
![screen shot 2018-06-22 at 6 59 21 pm](https://user-images.githubusercontent.com/4016985/41802566-a3955c42-764f-11e8-883c-4cf4ed0b4432.png)

