### PR TITLE
Header hot fix

### DIFF
--- a/app/assets/stylesheets/layout/_body.scss
+++ b/app/assets/stylesheets/layout/_body.scss
@@ -9,7 +9,6 @@ body {
   }
 
   @include breakpoint("large") {
-    grid-gap: 0;
     grid-template-areas: "header"
                          "main"
                          "footer";

--- a/app/assets/stylesheets/layout/_hero.scss
+++ b/app/assets/stylesheets/layout/_hero.scss
@@ -13,7 +13,7 @@ $_media-height: 100vh;
     height: auto;
     position: static;
     grid-template-columns: repeat(7, 1fr);
-    grid-template-rows: repeat(5, 0.5fr);
+    grid-template-rows: repeat(4, 0.5fr);
   }
 
   &::before,
@@ -43,7 +43,8 @@ $_media-height: 100vh;
 
     @include breakpoint("large") {
       grid-column: 7 / 8;
-      grid-row: 3 / 7;
+      grid-row: 3 / 5;
+      transform: translateY($spacing-x-large);
     }
   }
 }


### PR DESCRIPTION
The `:after` element on the header was unnecessarily pushing the main content down too far since I had the grid extending another frame below the main image. I adjusted this by making the grid terminate at the bottom of the hero image and then using a translate to push the gradient below the image to give that overlapping effect.

**Before**
![screen shot 2018-09-21 at 2 35 26 pm](https://user-images.githubusercontent.com/2642348/45899764-c1022280-bdab-11e8-90b3-7ab2dbad3db9.png)

**After**
![screen shot 2018-09-21 at 2 35 20 pm](https://user-images.githubusercontent.com/2642348/45899768-c3647c80-bdab-11e8-8a3c-252e33dff421.png)
