### PR TITLE
Wires up the RSVP link and the See All Events link

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 APPLICATION_HOST=localhost:3000
 ASSET_HOST=localhost:3000
+MEETUP_URL=https://www.meetup.com
 PORT=3000
 RACK_ENV=development
 RACK_MINI_PROFILER=0

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+MEETUP_URL=https://www.meetup.com

--- a/app/view_models/meetup_event.rb
+++ b/app/view_models/meetup_event.rb
@@ -51,6 +51,21 @@ class MeetupEvent
     venue[:state]
   end
 
+  def rsvp_url
+    data[:link]
+  end
+
+  def group_name
+    data[:group][:urlname]
+  end
+
+  def events_url
+    URI.join(
+      ENV.fetch("MEETUP_URL"),
+      "#{group_name}/events"
+    ).to_s
+  end
+
   private
   attr_reader :data
 

--- a/app/views/homes/_event_details.html.erb
+++ b/app/views/homes/_event_details.html.erb
@@ -1,8 +1,10 @@
-<p class="events__item-title">
+<p class="events__item-title" data-role="event-name">
   <%= event.name %>
 </p>
 
-<p><time><%= event.date %></time></p>
+<p data-role="event-date-info">
+  <time><%= event.date %></time>
+</p>
 
 <p>
   <time>
@@ -14,7 +16,7 @@
   </time>
 </p>
 
-<address>
+<address data-role="event-venue-info">
   <%= event.venue_name %><br>
   <%= event.address %><br>
   <%= "#{event.city}, #{event.state}" %>
@@ -23,8 +25,15 @@
 <p>
   <%= link_to(
     "RSVP",
-    "#",
-    class: "cta--primary",
-    target: "_blank"
+    event.rsvp_url,
+    class: "cta--primary"
+  ) %>
+</p>
+
+<p>
+  <%= link_to(
+    "See all events",
+    event.events_url,
+    class: "upcoming-event__button"
   )%>
 </p>

--- a/spec/support/view_helpers.rb
+++ b/spec/support/view_helpers.rb
@@ -1,0 +1,13 @@
+module ViewHelpers
+  def within_role(role, &block)
+    within(%{[data-role="#{role}"]}, &block)
+  end
+
+  def have_role_text(role, text)
+    have_css(%{[data-role*="#{role}"]}, text: text)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ViewHelpers, type: :view
+end

--- a/spec/view_models/meetup_event_spec.rb
+++ b/spec/view_models/meetup_event_spec.rb
@@ -97,4 +97,26 @@ RSpec.describe MeetupEvent do
       expect(event.state).to eq("Massachusetts")
     end
   end
+
+  describe "#rsvp_url" do
+    it "returns the event URL for the meetup group" do
+      meetup_event_url = "https://www.meetup.com/abc/events/123"
+      meetup_event_data = {"link" => meetup_event_url}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.rsvp_url).to eq(meetup_event_url)
+    end
+  end
+
+  describe "#events_url" do
+    it "returns the events URL for the meetup group" do
+      group_name = "bostonrb"
+      meetup_event_data = {"group" => {"urlname" => group_name}}
+
+      event = MeetupEvent.new(meetup_event_data)
+
+      expect(event.events_url).to eq("https://www.meetup.com/bostonrb/events")
+    end
+  end
 end

--- a/spec/views/homes/_event_details.html.erb_spec.rb
+++ b/spec/views/homes/_event_details.html.erb_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "homes/_event_details.html.erb_spec.rb", type: :view do
+  it "renders details about the event" do
+    event = MeetupEvent.new(event_data)
+
+    render("homes/event_details", event: event)
+
+    expect(rendered).to have_event_name(event.name)
+
+    within_role("event-date-info") do
+      expect(rendered).to have_text(event.date)
+      expect(rendered).to have_text(event.formatted_start_time)
+      expect(rendered).to have_text(event.formatted_end_time)
+    end
+
+    within_role("event-venue-info") do
+      expect(rendered).to have_text(event.venue_name)
+      expect(rendered).to have_text(event.address)
+      expect(rendered).to have_text(event.city)
+      expect(rendered).to have_text(event.state)
+    end
+
+    expect(rendered).to have_link("RSVP", href: event.rsvp_url)
+    expect(rendered).to have_link("See all events", href: event.events_url)
+  end
+
+  def have_event_name(name)
+    have_role_text("event-name", name)
+  end
+
+  def event_data
+    JSON.parse(
+      File.read(Rails.root.join("spec/fixtures/meetup_events.json"))
+    ).first
+  end
+end

--- a/spec/views/homes/_events_view_spec.rb
+++ b/spec/views/homes/_events_view_spec.rb
@@ -1,11 +1,13 @@
-RSpec.describe "homes/_events.html.erb" do
+RSpec.describe "homes/_events.html.erb", type: :view do
   context "when the next event is unknown" do
     it "display that the upcoming event is unknown" do
       assign(:upcoming_event, UnknownMeetupEvent.new)
 
       render
 
-      expect(rendered).to match("No Upcoming Event")
+      within_role("upcoming-event-details") do
+        expect(rendered).to have_text("No Upcoming Event")
+      end
     end
   end
 end


### PR DESCRIPTION
Summary:
We want the process of RSVP'ing and viewing all upcoming events to be as
easy as possible.

This PR:
Updates the RSVP link to direct the user to the meetup event where they
can RSVP for the event.
Updates "See all events" link to direct the user to meetup page that
shows all upcoming events.

Demo: http://recordit.co/eT18B7A8xt