### PR TITLE
Add skip to content link

### DIFF
--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -5,3 +5,4 @@
 @import "lists";
 @import "media";
 @import "typography";
+@import "utilities";

--- a/app/assets/stylesheets/base/_utilities.scss
+++ b/app/assets/stylesheets/base/_utilities.scss
@@ -1,0 +1,10 @@
+.skip-to-main {
+  @include hide-visually;
+
+  &:active,
+  &:focus {
+    @include hide-visually("unhide");
+    position: absolute;
+    z-index: get-z-index("layout");
+  }
+}

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,4 +1,4 @@
-<main class="content">
+<main class="content" id="main-content" tabindex="-1">
   <%= render "about_us" %>
   <%= render "events" %>
   <%= render "nav" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
 </head>
 <body class="<%= body_class %>">
   <%= render "flashes" -%>
+  <a class="skip-to-main" href="#main-content">Skip to Main Content</a>
   <%= render "layouts/header" %>
   <%= yield %>
   <%= render "layouts/footer" %>


### PR DESCRIPTION
This PR adds a [skip to main content](https://webaim.org/techniques/skipnav/) link that is only visually present on focus. It navigates the user past the header to the main event content.

![screen shot 2018-10-02 at 10 06 29 am](https://user-images.githubusercontent.com/2642348/46353799-0c79c380-c62b-11e8-8d16-5af24014f661.png)
