### PR TITLE
Update the staging environment to mimic the production environment

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,1 @@
+require_relative "production"


### PR DESCRIPTION
Summary:
The staging app was incredibly slow to load. Upon further investigation,
the slowness is due to the app looking for a
config/environments/staging.rb file and failing to find one, which means
we're losing out of the speediness of running our app in a
production-like environment.

Options:
1. Set the RAILS_ENV config variable in Heroku to production.
2. Add an environment config file for staging.rb that pulls in
production settings.

I've opted for the second option because:
1. I like how obvious it is that staging is intended to mimic production
2. Having a staging config file gives us a space to add future staging
specific settings.
3. I'm fond of easily telling when I'm in a staging vs production
environment.