### PR TITLE
Set default value for RACK_TIMEOUT

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,4 +29,4 @@ Rails.application.configure do
     "Cache-Control" => "public, max-age=31557600",
   }
 end
-Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
+Rack::Timeout.timeout = ENV.fetch("RACK_TIMEOUT", 10).to_i


### PR DESCRIPTION
Summary:
Now that the staging environment is mimicking the production
environment, all production environment variables need to be defined or
have a default value when deployed to the staging environment.