### PR TITLE
Include rack-timeout gem in staging environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,6 @@ group :test do
   gem "webmock"
 end
 
-group :production do
+group :staging, :production do
   gem "rack-timeout"
 end


### PR DESCRIPTION
Summary:
The rack-timeout gem needs to be available to the staging environment as
staging mimics production.