### PR TITLE
Remove delayed_job

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,5 @@ module Bostonrb
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.load_defaults 5.1
     config.generators.system_tests = nil
-    config.active_job.queue_adapter = :delayed_job
   end
 end


### PR DESCRIPTION
Why:
Deploying to staging is failing as the application is looking for a
delayed_job.rb file. We do not need delayed job at this time so we're
opting to remove it for now.