### PR TITLE
Address security warning for nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     minitest (5.11.1)
     multi_xml (0.6.0)
     nio4r (2.2.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     pg (0.21.0)
     pry (0.11.3)
@@ -263,4 +263,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.6


### PR DESCRIPTION
Bundler-audit report the following security advisory for nokogiri. This
PR updates nokogiri to the recommended version.

Name: nokogiri
Version: 1.8.4
Advisory: CVE-2018-14404
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1785
Title: Nokogiri gem, via libxml2, is affected by multiple
vulnerabilities
Solution: upgrade to >= 1.8.5