### PR TITLE
Show only the state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "bundler-audit", ">= 0.5.0", require: false
+  gem "capybara"
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ DEPENDENCIES
   awesome_print
   bourbon (~> 5.0)
   bundler-audit (>= 0.5.0)
+  capybara
   database_cleaner
   dotenv-rails
   factory_bot_rails

--- a/app/view_models/meetup_event.rb
+++ b/app/view_models/meetup_event.rb
@@ -47,10 +47,6 @@ class MeetupEvent
     venue[:city]
   end
 
-  def state
-    venue[:state]
-  end
-
   def rsvp_url
     data[:link]
   end

--- a/app/views/homes/_event_details.html.erb
+++ b/app/views/homes/_event_details.html.erb
@@ -19,7 +19,7 @@
 <address data-role="event-venue-info">
   <%= event.venue_name %><br>
   <%= event.address %><br>
-  <%= "#{event.city}, #{event.state}" %>
+  <%= event.city %>
 </address>
 
 <p>

--- a/spec/features/user_views_upcoming_events_spec.rb
+++ b/spec/features/user_views_upcoming_events_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "user views details for the next event" do
       expect(page).to have_content("Fake Project Night")
       expect(page).to have_content("thoughtbot")
       expect(page).to have_content("41 Winter Street, 6th Floor")
-      expect(page).to have_content("Boston, MA")
+      expect(page).to have_content("Boston")
       expect(page).to have_content("6:00PM to 8:00PM")
     end
   end

--- a/spec/support/view_helpers.rb
+++ b/spec/support/view_helpers.rb
@@ -1,8 +1,4 @@
 module ViewHelpers
-  def within_role(role, &block)
-    within(%{[data-role="#{role}"]}, &block)
-  end
-
   def have_role_text(role, text)
     have_css(%{[data-role*="#{role}"]}, text: text)
   end

--- a/spec/view_models/meetup_event_spec.rb
+++ b/spec/view_models/meetup_event_spec.rb
@@ -88,16 +88,6 @@ RSpec.describe MeetupEvent do
     end
   end
 
-  describe "#state" do
-    it "returns the venue state" do
-      meetup_event_data = {"venue" => {"state" => "Massachusetts"}}
-
-      event = MeetupEvent.new(meetup_event_data)
-
-      expect(event.state).to eq("Massachusetts")
-    end
-  end
-
   describe "#rsvp_url" do
     it "returns the event URL for the meetup group" do
       meetup_event_url = "https://www.meetup.com/abc/events/123"

--- a/spec/views/homes/_event_details.html.erb_spec.rb
+++ b/spec/views/homes/_event_details.html.erb_spec.rb
@@ -6,18 +6,12 @@ RSpec.describe "homes/_event_details.html.erb_spec.rb", type: :view do
 
     expect(rendered).to have_event_name(event.name)
 
-    within_role("event-date-info") do
-      expect(rendered).to have_text(event.date)
-      expect(rendered).to have_text(event.formatted_start_time)
-      expect(rendered).to have_text(event.formatted_end_time)
-    end
-
-    within_role("event-venue-info") do
-      expect(rendered).to have_text(event.venue_name)
-      expect(rendered).to have_text(event.address)
-      expect(rendered).to have_text(event.city)
-      expect(rendered).to have_text(event.state)
-    end
+    expect(rendered).to have_content(event.date)
+    expect(rendered).to have_content(event.formatted_start_time)
+    expect(rendered).to have_content(event.formatted_end_time)
+    expect(rendered).to have_content(event.venue_name)
+    expect(rendered).to have_content(event.address)
+    expect(rendered).to have_content(event.city)
 
     expect(rendered).to have_link("RSVP", href: event.rsvp_url)
     expect(rendered).to have_link("See all events", href: event.events_url)

--- a/spec/views/homes/_events_view_spec.rb
+++ b/spec/views/homes/_events_view_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe "homes/_events.html.erb", type: :view do
 
       render
 
-      within_role("upcoming-event-details") do
-        expect(rendered).to have_text("No Upcoming Event")
-      end
+      expect(rendered).to have_no_upcoming_event_message
     end
+  end
+
+  def have_no_upcoming_event_message
+    have_role_text("upcoming-event", "No Upcoming Event")
   end
 end


### PR DESCRIPTION
Summary:
The Meetup API does not consistently return the state information.
Rather that update the view to handle both states, we have opted to
remove the state.

This PR also brings in Capybara. After removing the state, certain view
specs were not failing as expected. The `within` function that resembles
the Capybara `within` function was calling the Rspec function
`alias_matcher`, defined in RSpec::Matchers::DSL. These tests have been
updated to use Capybara's RSpec matchers.