### PR TITLE
Remove unnecessary step in CircleCI build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
 
       # Database setup
-      - run: bin/rails db:create --trace
       - run: bin/rails db:schema:load --trace
 
       # Run tests


### PR DESCRIPTION
Summary:
Removes the `db:create` command, as the DB is created as part of the
Postgres image.

Before this change, we were attempting to recreate an existing database,
which produces the following message in the CircleCI build logs:
** Execute `db:create`
Database 'bostonrb_test' already exists

<img width="437" alt="screen shot 2018-10-06 at 12 34 46 pm" src="https://user-images.githubusercontent.com/4016985/46573558-ffc7d900-c964-11e8-9cc5-1c61872f71fd.png">
