### PR TITLE
Ignore past events returned by the Meetup API

### DIFF
--- a/app/clients/meetup_api.rb
+++ b/app/clients/meetup_api.rb
@@ -2,13 +2,13 @@ class MeetupApi
   BASE_URL = "https://api.meetup.com/".freeze
 
   def upcoming_events(group_name)
-    HttpClient.get(events_path(group_name))
+    HttpClient.get(upcoming_events_path(group_name))
   end
 
   private
 
-  def events_path(group_name)
-    build_url("#{group_name}/events")
+  def upcoming_events_path(group_name)
+    build_url("#{group_name}/events?has_ended=false")
   end
 
   def build_url(path)

--- a/spec/clients/meetup_api_spec.rb
+++ b/spec/clients/meetup_api_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MeetupApi do
 
       expect(HttpClient)
         .to have_received(:get)
-        .with("https://api.meetup.com/#{meetup_group}/events")
+        .with("https://api.meetup.com/#{meetup_group}/events?has_ended=false")
     end
   end
 end


### PR DESCRIPTION
Summary:
In the past, the Meetup API `/events` endpoint has returned
upcoming events in ascending order. Recently, this endpoint returned a
past event with the status "upcoming". After about 24 hours, the Meetup
API corrected this issue and the response no longer included the past
event. An [issue][1] has been submitted to the Meetup API.

The Meetup API has proven we can't rely on `/events` to
return upcoming events only. Before we take matters into our own hands
and filter events based on their start time, this PR adds the
`has_ended` parameter. Testing locally, the addition of this parameter
has prevented past events from being returned.

[1]: https://github.com/meetup/api/issues/301

Further details about this PR:
Additional comments exist on this PR because these changes used to filter out past events based on the event start time and include a refactor. With the discovery of the `has_ended` parameter, I've stripped out all of these changes with the intent to trust the Meetup API once more until proven wrong.