### PR TITLE
Force SSL

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module Bostonrb
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.load_defaults 5.1
     config.generators.system_tests = nil
+
+    if ENV.fetch("FORCE_HTTPS", false)
+      config.force_ssl = true
+      routes.default_url_options[:protocol] = "https"
+    end
   end
 end


### PR DESCRIPTION
Summary:
The Cloudflare setup includes a shared Cloudflare Universal SSL
certificate. This means the site is accessible over `https`. However, the
assets within the site don’t load because of mixed
content warning as the assets are being requested over `http`.

This PR adds an environment variable to configure the app to force SSL.
`force_ssl` will rewrite the links to use `https` and visiting `http://`
will redirect to `https://`.

Console Errors:
<img width="1269" alt="screen shot 2018-10-09 at 3 05 43 pm" src="https://user-images.githubusercontent.com/4016985/46692271-dad99d00-cbd4-11e8-84b1-c170b9c4c52a.png">
