### PR TITLE
Fix slack invite

### DIFF
--- a/app/views/homes/_nav.html.erb
+++ b/app/views/homes/_nav.html.erb
@@ -5,7 +5,7 @@
       <%= link_to("Meetup", "https://www.meetup.com/bostonrb/") %>
     </li>
     <li class="nav__item">
-      <%= link_to("Slack", "http://slack.bostonrb.org/") %>
+      <%= link_to("Slack", ENV.fetch('SLACK_JOIN_URL', "https://communityinviter.com/apps/bostonrb/bostonrb")) %>
     </li>
     <li class="nav__item">
       <%= link_to("Twitter", "https://twitter.com/bostonrb/") %>


### PR DESCRIPTION
## the change
- update the slack link so it can be configured via environment variable
- default the value to a working link (hosted by https://communityinviter.com)

Community Inviter is configured to automatically send an email inviting the user to slack - try it out here https://communityinviter.com/apps/bostonrb/bostonrb


## background
Alternatives considered:
- [slackin](https://github.com/rauchg/slackin) Our existing solution. Looks abandoned, and I'm too lazy to debug the crash stacktrace: 
![image](https://user-images.githubusercontent.com/222655/104258671-0996eb80-544e-11eb-8842-1087d6b9fe37.png)

- [launchpass](https://launchpass.com/) same idea as Community Inviter, I think