### PR TITLE
remove activerecord

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,11 @@
 require_relative 'boot'
-require 'rails/all'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'action_mailer/railtie'
+require 'active_job/railtie'
+require 'action_cable/engine'
+require 'rails/test_unit/railtie'
+require 'sprockets/railtie'
 
 Bundler.require(*Rails.groups)
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,10 +31,10 @@ Rails.application.configure do
   config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  # config.active_record.migration_error = :page_load
 
   # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
+  #   config.active_record.verbose_query_logs = true
 
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
   end
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # config.active_record.dump_schema_after_migration = false
 
   if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
     ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,5 +36,5 @@ plugin :tmp_restart
 on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
-  ActiveRecord::Base.establish_connection
+  # ActiveRecord::Base.establish_connection
 end


### PR DESCRIPTION
since the database is unused (confirmed there are no tables and no data in prod), this change makes it easier to set up local development. 

Here's what it looks like when booting without a (i must emphasize: useless) postgres database.

![image](https://user-images.githubusercontent.com/222655/104260165-f1749b80-5450-11eb-9ab1-e8134132a0d5.png)


Revert to undo. 

`rails/all` is defined here https://github.com/rails/rails/blob/v6.0.2.2/railties/lib/rails/all.rb